### PR TITLE
BUGFIX // Fix layout caching bug

### DIFF
--- a/Resources/Private/Fusion/Content/MultiColumn.fusion
+++ b/Resources/Private/Fusion/Content/MultiColumn.fusion
@@ -87,6 +87,19 @@ prototype(TechDivision.NodeTypes.FlexColumnLayouts:MultiColumn) < prototype(Neos
                 }
                 style = TechDivision.NodeTypes.FlexColumnLayouts:Helper.VisualStyles
             }
+
+            @cache {
+                mode = 'cached'
+                entryIdentifier {
+                    node = ${node}
+                }
+                entryTags {
+                    # Whenever the node changes the matched condition could change
+                    1 = ${Neos.Caching.nodeTag(node)}
+                    # Whenever the parent nodes changes the layout could change
+                    2 = ${Neos.Caching.nodeTag(parentNode)}
+                }
+            }
         }
     }
     renderer = afx`


### PR DESCRIPTION
**Given**:
- Tested with plugin version 3.1.2 
- Fresh Two column content ( Neos.NodeTypes.ColumnLayouts:TwoColumn )

**Problem**:
- If you change the layout from a contentCollection in the neos backend, the new layout is not shown due to a caching problem

**Solution**:
- Clear cache when parent node changed